### PR TITLE
Unknown keys handling

### DIFF
--- a/lib/validate.ex
+++ b/lib/validate.ex
@@ -81,6 +81,19 @@ defmodule Validate do
         end
       end)
 
+      {value, errors} =
+        if opts.rules[:type] == :map do
+          opts = %{
+            value: opts.value,
+            unknown: Keyword.get(opts.rules, :unknown, :remove),
+            rules: opts.rules[:map],
+            path: opts.path ++ [opts.valueName]
+          }
+          handle_unknown(opts.value, value, errors, opts)
+        else
+          {value, errors}
+        end
+
     {value, errors}
   end
 
@@ -153,6 +166,7 @@ defmodule Validate do
   defp get_handler(%{rule: :<}), do: &Validate.Rules.LessThan.validate/1
   defp get_handler(%{rule: :<=}), do: &Validate.Rules.LessThanEqual.validate/1
   defp get_handler(%{rule: :==}), do: &Validate.Rules.Equal.validate/1
+  defp get_handler(%{rule: :unknown}), do: &Validate.Rules.Unknown.validate/1
 
   defp get_handler(%{rule: rule}) do
     rule_str = Atom.to_string(rule)
@@ -163,6 +177,37 @@ defmodule Validate do
       &module.validate/1
     else
       raise "#{rule} validator does not exist"
+    end
+  end
+
+  defp handle_unknown(original, result, errors, opts) do
+    case opts.unknown do
+      :reject ->
+        unknown_keys = Map.keys(original) -- Map.keys(opts.rules)
+
+        if unknown_keys == [] do
+          {result, errors}
+        else
+          {result,
+            errors ++
+              Enum.map(unknown_keys, fn key ->
+                %Error{
+                  path: opts.path ++ [key],
+                  rule: :unknown,
+                  message: "unknown key"
+                }
+              end)}
+        end
+
+      :allow ->
+        extra_keys = Map.drop(original, Map.keys(opts.rules))
+        {Map.merge(result, extra_keys), errors}
+
+      :remove ->
+        {result, errors}
+
+      _ ->
+        raise "invalid unknown mode: #{opts.unknown}"
     end
   end
 end

--- a/lib/validate/rules/unknown.ex
+++ b/lib/validate/rules/unknown.ex
@@ -1,0 +1,9 @@
+defmodule Validate.Rules.Unknown do
+  @moduledoc false
+
+  import Validate.Validator
+
+  def validate(%{value: value}) do
+    success(value)
+  end
+end

--- a/lib/validate/rules/unknown.ex
+++ b/lib/validate/rules/unknown.ex
@@ -3,6 +3,12 @@ defmodule Validate.Rules.Unknown do
 
   import Validate.Validator
 
+  # Dummy one to not panic with unknown validator not present.
+  # We cannot fully rely upon this style like other validators
+  # as the map value gets modified in cases like unknown: allow
+  # which distracts the other validators.
+  # Hence an explcit validator added on the validator.ex to handle
+  # at the end of the map validation
   def validate(%{value: value}) do
     success(value)
   end


### PR DESCRIPTION
```elixir
# deps
{:validate, git: "https://github.com/voigerio/validate.git", tag: "unknown"}
```

- `unknown` option is added for map types, which can be one of [:remove, :reject, :allow]
- this `unknown` defaults to `:remove` (current behaviour)
- For us, we need :reject most of the times.
Rest of the usage is same as the base, check the README for more details.

```elixir
input = %{
  "name" => "Jane Doe",
  "colors" => ["red", "green"],
  "address" => %{
    "line0" => "sunga",
    "line1" => "123 Fake St",
    "city" => "Saskatoon",
  },
  "bad key" => "value",
  "friends" => [
    %{"name" => "John", "email" => "john@example.com"},
    %{"name" => "Michelle", "email" => "michelle@example.com", "sunda" => 9}
  ]
}

rules = [
  required: true,
  type: :map,
  unknown: :reject,
  map: %{
    "name" => [required: true, type: :string],
    "colors" => [
      required: true,
      type: :list,
      list: [required: true, type: :string, in: ~w[blue orange red green purple]]
    ],
    "address" => [
      required: true,
      type: :map,
      unknown: :reject,
      map: %{
        "line1" => [required: true, type: :string],
        "city" => [required: true, type: :string],
      }
    ],
    "friends" => [
      required: true,
      type: :list,
      list: [
        required: true,
        type: :map,
        map: %{
          "name" => [required: true, type: :string],
          "email" => [required: true, type: :string]
        }
      ]
    ]
  }
]

result = Validate.validate(input, rules)
IO.inspect(result)

```